### PR TITLE
Update sts.go in median

### DIFF
--- a/src/etapa_01/desafios/stats/sts/sts.go
+++ b/src/etapa_01/desafios/stats/sts/sts.go
@@ -39,7 +39,7 @@ func MedianFloat64(x []float64) float64 {
 	sort.Float64s(x)
 
 	if len(x)%2 == 0 {
-		return (x[len(x)/2] + x[len(x)/2+1]) / 2.
+		return (x[len(x)/2] + x[len(x)/2-1]) / 2.
 	} else {
 		return x[len(x)/2+1]
 	}


### PR DESCRIPTION
Quando o array for par, o (len / 2) vai retornar o meio, porém o array começa no index 0, então precisamos tirar a média da posição que retornou menos a posição anterior, e não a seguinte.